### PR TITLE
fixed the typo that caused the error

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To compile and run the sample-server, do the following (relative to the previous
     cd build
     cmake ..
     make
-    ./sample-server -n _mem_1
+    ./sample-server -n mem1
     
 #### Windows (CMD)
 
@@ -76,7 +76,7 @@ To compile and run the sample-server, do the following (relative to the previous
     cd build
     cmake .. -DCMAKE_GENERATOR_PLATFORM=x64
     MSBuild.exe sample-server.sln, /property:Configuration=Release /property:Platform=x64
-    Release\x64\sample-server.exe -n _mem_1
+    Release\x64\sample-server.exe -n mem1
     
 If the last command doesn't work, then check whether the executable is located in `Release\sample-server.exe` without `x64`.    
 


### PR DESCRIPTION
The name of the server is mem1 and not _mem1_ as earlier mentioned. I found out the hard way as the code did not run (client didn't connect to server) with the original step. 
<img width="1136" alt="Screen Shot 2020-04-17 at 1 46 04 PM" src="https://user-images.githubusercontent.com/395039/79613781-0be13a80-80b4-11ea-914c-3699c30ef5bd.png">

Fixed it now after verifying in Line 56 of NativeFxApp.java program - TextField tf = new TextField("mem1");